### PR TITLE
Add next plan feature

### DIFF
--- a/.github/workflows/main_aceguap.yml
+++ b/.github/workflows/main_aceguap.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update the `runs-on` property in the build job of `.github/workflows/main_aceguap.yml` to `ubuntu-latest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bless1717/Btc/pull/5?shareId=2f559ae7-dbba-44b3-9cb2-db461f5b29e8).